### PR TITLE
Add watch to images

### DIFF
--- a/images/mysql/8.0/Dockerfile
+++ b/images/mysql/8.0/Dockerfile
@@ -4,6 +4,7 @@ RUN rm -f /etc/apt/sources.list.d/mysql.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
+    watch \
     curl \
     wget && \
     apt-get clean && \

--- a/images/mysql/8.4/Dockerfile
+++ b/images/mysql/8.4/Dockerfile
@@ -1,6 +1,7 @@
 FROM mysql:8.4.9-oracle@sha256:c36050afdca850f23cef85703f84c7531a5ae155a11b5ee1c60acb09937c4084
 
 RUN microdnf install -y \
+    watch \
     curl \
     wget && \
     microdnf clean all

--- a/images/mysql/9.5.0/Dockerfile
+++ b/images/mysql/9.5.0/Dockerfile
@@ -1,6 +1,7 @@
 FROM mysql:9.5.0-oracle@sha256:57c892ddeb17e6c7dddf219914db017b2cf3e2797806a75424444b83622cc8ef
 
 RUN microdnf install -y \
+    watch \
     curl \
     wget && \
     microdnf clean all

--- a/images/network/debug/Dockerfile
+++ b/images/network/debug/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
+    watch \
     curl \
     wget \
     dnsutils \

--- a/images/postgresql/13/Dockerfile
+++ b/images/postgresql/13/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
+    watch \
     curl \
     wget \
     gnupg \

--- a/images/postgresql/14/Dockerfile
+++ b/images/postgresql/14/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
+    watch \
     curl \
     wget \
     gnupg \

--- a/images/postgresql/15/Dockerfile
+++ b/images/postgresql/15/Dockerfile
@@ -3,6 +3,7 @@ FROM debian:bookworm-slim@sha256:96e378d7e6531ac9a15ad505478fcc2e69f371b10f5cdf8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
+    watch \
     curl \
     wget \
     gnupg \

--- a/images/ruby/3.3/Dockerfile
+++ b/images/ruby/3.3/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:3.3-slim@sha256:5340ab7cd6317c45a0a7e2818857b930ff61ee92ffd661dec72738
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
+    watch \
     curl \
     wget \
     git \

--- a/images/ruby/3.4/Dockerfile
+++ b/images/ruby/3.4/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:3.4-slim@sha256:384bff5c64f366283c55cb5d42fd339025d4d44741ed7e7c25923e
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
+    watch \
     curl \
     wget \
     git \

--- a/images/ruby/4.0/Dockerfile
+++ b/images/ruby/4.0/Dockerfile
@@ -3,6 +3,7 @@ FROM ruby:4.0-slim@sha256:3d2d07ec3c267107a2a253327c108c1e5b74ea84cfa5ab125f127b
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
+    watch \
     curl \
     wget \
     git \


### PR DESCRIPTION
This pull request adds the `watch` utility to several Docker images across different services and language versions. Including `watch` improves debugging and monitoring capabilities within these containers, making it easier to observe command output changes in real time. The main changes are grouped by the type of image updated.

**MySQL images:**

* Added `watch` to the package installation steps in `mysql/8.0`, `mysql/8.4`, and `mysql/9.5.0` Dockerfiles, ensuring the utility is available in all supported MySQL versions. [[1]](diffhunk://#diff-2c83e1555103616adc5c3c87f9bcbc57076fc4b9706ef6864d30aa7108178c1dR7) [[2]](diffhunk://#diff-e5161466333201418e441c53a2b52177115c6f5b0f0afd9168b390e426a4b1d8R4) [[3]](diffhunk://#diff-113661619227561e1746908c4888f4a7a0a4f8b6200ba109141d8ba5603f3432R4)

**PostgreSQL images:**

* Updated `postgresql/13`, `postgresql/14`, and `postgresql/15` Dockerfiles to include `watch` in the installed packages. [[1]](diffhunk://#diff-d955ece736ab33e89933e1f7000da048f73892eb2501befadf1642f5690879cbR6) [[2]](diffhunk://#diff-920ae5c71f03ecee89c2c48b9e41b5fae7e49e099153b10ca5ee0b8f8d192a1fR6) [[3]](diffhunk://#diff-8b172c11bcb66f74cac46e026b62bd1c48e50ef70ed3d5758c4a66c02b4d8850R6)

**Ruby images:**

* Added `watch` to the package list in `ruby/3.3`, `ruby/3.4`, and `ruby/4.0` Dockerfiles, making it available for all recent Ruby image variants. [[1]](diffhunk://#diff-b825972b8376f859d6a1668d11904aa2a1183f8b6304e28bc0dec1375a64883cR6) [[2]](diffhunk://#diff-9d9258ce335e19cee2a7a4c25010fbe61ba40567c03f070687dd83c8d3ce52d0R6) [[3]](diffhunk://#diff-95de15479d76e5ecfebac89337292aaad04146e303e74bdb2166f3038e39a5b2R6)

**Network debug image:**

* Included `watch` in the `network/debug` Dockerfile, enhancing its utility for real-time monitoring during network troubleshooting.