### PR TITLE
Add an image pull policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -612,6 +612,7 @@ See [bin/README.md](bin/README.md) for detailed usage and examples.
 5. Update the manifest to reference the correct image:
    ```yaml
    image: ghcr.io/c-gerke/k8s-debug-pods/category-version:latest
+   imagePullPolicy: Always
    # Example: ghcr.io/c-gerke/k8s-debug-pods/redis-7.0:latest
    ```
 
@@ -643,6 +644,7 @@ You can also create pod manifests that use external images directly (e.g., Perco
 2. Reference the external image directly:
    ```yaml
    image: percona:8.0.36-28@sha256:1128d56e64711ed65cb0c57041048967ee5875a2167d708d327885fd1f995fa0
+   imagePullPolicy: Always
    # Use SHA pinning for production images
    ```
 

--- a/bin/README.md
+++ b/bin/README.md
@@ -215,4 +215,3 @@ The script automatically:
 # Remove all debug pods
 ./bin/cleanup-debug-pods -n my-app --all
 ```
-

--- a/bin/README.md
+++ b/bin/README.md
@@ -20,7 +20,7 @@ Deploy a debug pod with intelligent resource allocation based on namespace quota
 
 **With Context and Namespace:**
 ```bash
-./bin/deploy-debug-pod -c wc-beta-px -n example-rails-app-pr1110 mysql/8.0
+./bin/deploy-debug-pod -c beta-cluster -n example-app mysql/8.0
 ```
 
 **Auto-exec into Pod:**

--- a/bin/cleanup-debug-pods
+++ b/bin/cleanup-debug-pods
@@ -74,7 +74,6 @@ done
 if [ -z "$CONTEXT" ]; then
     CONTEXT=$(kubectl config current-context)
 fi
-
 if [ -z "$NAMESPACE" ]; then
     NAMESPACE=$(kubectl config view --minify --output 'jsonpath={..namespace}')
     if [ -z "$NAMESPACE" ]; then
@@ -131,4 +130,3 @@ else
         echo "Use --all to delete all debug pods or --name <pod-name> to delete a specific pod"
     fi
 fi
-

--- a/bin/deploy-debug-pod
+++ b/bin/deploy-debug-pod
@@ -294,7 +294,6 @@ if [ -z "$IMAGE_TYPE" ]; then
     echo ""
     show_usage
 fi
-
 if [ -z "$CONTEXT" ]; then
     CONTEXT=$(kubectl config current-context)
 fi
@@ -428,4 +427,3 @@ if [ "$AUTO_EXEC" = true ]; then
     echo "Executing into pod..."
     kubectl --context="$CONTEXT" -n "$NAMESPACE" exec -it "$POD_NAME" -- /bin/bash
 fi
-

--- a/images/mysql/9.5.0/Dockerfile
+++ b/images/mysql/9.5.0/Dockerfile
@@ -7,4 +7,3 @@ RUN microdnf install -y \
     microdnf clean all
 
 CMD ["/bin/bash"]
-

--- a/images/network/debug/Dockerfile
+++ b/images/network/debug/Dockerfile
@@ -21,4 +21,3 @@ RUN apt-get update && \
            /var/cache/apt/*.bin
 
 CMD ["/bin/bash"]
-

--- a/images/ruby/4.0/Dockerfile
+++ b/images/ruby/4.0/Dockerfile
@@ -21,4 +21,3 @@ RUN apt-get update && \
            /var/cache/apt/*.bin
 
 CMD ["/bin/bash"]
-

--- a/pods/mysql/8.0.yml
+++ b/pods/mysql/8.0.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: ghcr.io/c-gerke/k8s-debug-pods/mysql-8.0:latest
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:
@@ -19,4 +20,3 @@ spec:
         memory: "128Mi"
         ephemeral-storage: "128Mi"
   restartPolicy: Never
-

--- a/pods/mysql/8.4.yml
+++ b/pods/mysql/8.4.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: ghcr.io/c-gerke/k8s-debug-pods/mysql-8.4:latest
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:
@@ -19,4 +20,3 @@ spec:
         memory: "128Mi"
         ephemeral-storage: "128Mi"
   restartPolicy: Never
-

--- a/pods/mysql/9.5.0.yml
+++ b/pods/mysql/9.5.0.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: ghcr.io/c-gerke/k8s-debug-pods/mysql-9.5.0:latest
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:
@@ -19,4 +20,3 @@ spec:
         memory: "128Mi"
         ephemeral-storage: "128Mi"
   restartPolicy: Never
-

--- a/pods/mysql/percona-8.0.yml
+++ b/pods/mysql/percona-8.0.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: percona:8.0.36-28@sha256:1128d56e64711ed65cb0c57041048967ee5875a2167d708d327885fd1f995fa0
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:
@@ -19,4 +20,3 @@ spec:
         memory: "128Mi"
         ephemeral-storage: "128Mi"
   restartPolicy: Never
-

--- a/pods/network/debug.yml
+++ b/pods/network/debug.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: ghcr.io/c-gerke/k8s-debug-pods/network-debug:latest
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:
@@ -18,4 +19,3 @@ spec:
         memory: "32Mi"
         ephemeral-storage: "32Mi"
   restartPolicy: Never
-

--- a/pods/postgresql/13.yml
+++ b/pods/postgresql/13.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: ghcr.io/c-gerke/k8s-debug-pods/postgresql-13:latest
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:
@@ -19,4 +20,3 @@ spec:
         memory: "128Mi"
         ephemeral-storage: "128Mi"
   restartPolicy: Never
-

--- a/pods/postgresql/14.yml
+++ b/pods/postgresql/14.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: ghcr.io/c-gerke/k8s-debug-pods/postgresql-14:latest
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:
@@ -19,4 +20,3 @@ spec:
         memory: "128Mi"
         ephemeral-storage: "128Mi"
   restartPolicy: Never
-

--- a/pods/postgresql/15.yml
+++ b/pods/postgresql/15.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: ghcr.io/c-gerke/k8s-debug-pods/postgresql-15:latest
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:
@@ -19,4 +20,3 @@ spec:
         memory: "128Mi"
         ephemeral-storage: "128Mi"
   restartPolicy: Never
-

--- a/pods/postgresql/percona-13.yml
+++ b/pods/postgresql/percona-13.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: percona/percona-postgresql-operator:2.5.0-ppg13-postgres
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:
@@ -19,4 +20,3 @@ spec:
         memory: "128Mi"
         ephemeral-storage: "128Mi"
   restartPolicy: Never
-

--- a/pods/ruby/3.3.yml
+++ b/pods/ruby/3.3.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: ghcr.io/c-gerke/k8s-debug-pods/ruby-3.3:latest
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:

--- a/pods/ruby/3.4.yml
+++ b/pods/ruby/3.4.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: ghcr.io/c-gerke/k8s-debug-pods/ruby-3.4:latest
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:

--- a/pods/ruby/4.0.yml
+++ b/pods/ruby/4.0.yml
@@ -9,6 +9,7 @@ spec:
   containers:
   - name: debug-container
     image: ghcr.io/c-gerke/k8s-debug-pods/ruby-4.0:latest
+    imagePullPolicy: Always
     command: ['sleep', '3600']
     resources:
       requests:
@@ -19,4 +20,3 @@ spec:
         memory: "128Mi"
         ephemeral-storage: "128Mi"
   restartPolicy: Never
-


### PR DESCRIPTION
This pull request standardizes the use of the `imagePullPolicy: Always` setting across all Kubernetes pod manifests and updates the documentation to reflect this best practice. It also includes minor cleanup of Dockerfiles and YAML files to remove unnecessary trailing blank lines.

**Kubernetes manifest improvements:**

* Added `imagePullPolicy: Always` to all pod manifest files (e.g., `pods/mysql/8.0.yml`, `pods/network/debug.yml`, `pods/postgresql/13.yml`, etc.) to ensure that the latest image is always pulled when a pod is created or restarted. [[1]](diffhunk://#diff-8cd443d0c5b8956869f582b02acbf7751005b6c6ab44023421a72124071d7f9eR12) [[2]](diffhunk://#diff-a031fdb28f16819b68c8bb0c52b2a54b5eb38a59d719725f1841cda9e1c5e3cbR12) [[3]](diffhunk://#diff-8303fa412e529c0991ab2a2c9a2e99a80fa3f46c329e2a688979a9028f875602R12) [[4]](diffhunk://#diff-eb40e8d63f818d33c71eb9e59865657a79859df591701c8543d009fd25d0fe5bR12) [[5]](diffhunk://#diff-2e8e454e7c70e3c8244d2cb42c2ff580d43bc6eaaee9ce5a581f792a666766faR12) [[6]](diffhunk://#diff-d00c58e96d6bb00f2b227bd4ab12bf09cf6dc329350eae67a6d034fbe92462adR12) [[7]](diffhunk://#diff-aab8466072723d625f1458cd67e046138b659f8365bb60cf63ac76de67f5498eR12) [[8]](diffhunk://#diff-edbc643ed4561c7afef0b3080c54fe1b04d1a89e0b3d1359abe975c008e90b3cR12) [[9]](diffhunk://#diff-070f21d17db9b4ee5cfb130f0edfaa0190f310d60969aa50685d8cfded05264bR12) [[10]](diffhunk://#diff-5130f759d36b2f263d0e1be11ef5d78a6b43253b157ab5936202dea02859a91bR12) [[11]](diffhunk://#diff-916cea9d283145f05c852d547aafad156e72f7ab7f9c73f351b643216500ad44R12) [[12]](diffhunk://#diff-85387a40dba2a81ad4cb80afd3244b26d89108b12b46e9dc769df8e01e8834ffR12)
* Updated the README documentation to include `imagePullPolicy: Always` in example YAML snippets, guiding users to follow this best practice. [[1]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R615) [[2]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R647)

**General cleanup:**

* Removed unnecessary trailing blank lines from Dockerfiles (e.g., `images/mysql/9.5.0/Dockerfile`, `images/network/debug/Dockerfile`, `images/ruby/4.0/Dockerfile`). [[1]](diffhunk://#diff-113661619227561e1746908c4888f4a7a0a4f8b6200ba109141d8ba5603f3432L10) [[2]](diffhunk://#diff-1a3c2c5a47e1783c31cb4aae570110a67fa5399c5f447c81e5d26fab9781e3d4L24) [[3]](diffhunk://#diff-95de15479d76e5ecfebac89337292aaad04146e303e74bdb2166f3038e39a5b2L24)
* Removed unnecessary trailing blank lines from pod YAML files for consistency. [[1]](diffhunk://#diff-8cd443d0c5b8956869f582b02acbf7751005b6c6ab44023421a72124071d7f9eL22) [[2]](diffhunk://#diff-070f21d17db9b4ee5cfb130f0edfaa0190f310d60969aa50685d8cfded05264bL22) [[3]](diffhunk://#diff-5130f759d36b2f263d0e1be11ef5d78a6b43253b157ab5936202dea02859a91bL22) [[4]](diffhunk://#diff-a031fdb28f16819b68c8bb0c52b2a54b5eb38a59d719725f1841cda9e1c5e3cbL22) [[5]](diffhunk://#diff-8303fa412e529c0991ab2a2c9a2e99a80fa3f46c329e2a688979a9028f875602L21) [[6]](diffhunk://#diff-eb40e8d63f818d33c71eb9e59865657a79859df591701c8543d009fd25d0fe5bL22) [[7]](diffhunk://#diff-916cea9d283145f05c852d547aafad156e72f7ab7f9c73f351b643216500ad44L22) [[8]](diffhunk://#diff-85387a40dba2a81ad4cb80afd3244b26d89108b12b46e9dc769df8e01e8834ffL22) [[9]](diffhunk://#diff-edbc643ed4561c7afef0b3080c54fe1b04d1a89e0b3d1359abe975c008e90b3cL22) [[10]](diffhunk://#diff-d00c58e96d6bb00f2b227bd4ab12bf09cf6dc329350eae67a6d034fbe92462adL22)

These changes help ensure that the latest container images are always used and improve the overall clarity and maintainability of the codebase.