### PR TITLE
Install the correct package instead of `watch`

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -424,7 +424,7 @@ kubectl delete pod <pod-name>
 - `netcat-traditional` - nc utility
 
 ### System Tools
-- `procps` - ps, top
+- `procps` - ps, top, watch
 - `htop` - interactive process viewer
 - `strace` - system call tracer
 - `lsof` - list open files
@@ -523,4 +523,3 @@ This approach ensures:
 - **Scalability**: Adding new pod types is just creating a new YAML file
 - **Flexibility**: Each pod type can have unique volumes, commands, security context
 - **Clarity**: Pod configuration is visible and version-controlled in YAML
-

--- a/images/mysql/8.0/Dockerfile
+++ b/images/mysql/8.0/Dockerfile
@@ -4,7 +4,7 @@ RUN rm -f /etc/apt/sources.list.d/mysql.list && \
     apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
-    watch \
+    procps \
     curl \
     wget && \
     apt-get clean && \

--- a/images/mysql/8.4/Dockerfile
+++ b/images/mysql/8.4/Dockerfile
@@ -1,7 +1,7 @@
 FROM mysql:8.4.10-oracle@sha256:d36d39a64cd12a5c1cc9e6aa2bfb5f8d4c81a2f6586e0a04a9ae13939db02209
 
 RUN microdnf install -y \
-    watch \
+    procps-ng \
     curl \
     wget && \
     microdnf clean all

--- a/images/mysql/9.5.0/Dockerfile
+++ b/images/mysql/9.5.0/Dockerfile
@@ -1,7 +1,7 @@
 FROM mysql:9.5.0-oracle@sha256:57c892ddeb17e6c7dddf219914db017b2cf3e2797806a75424444b83622cc8ef
 
 RUN microdnf install -y \
-    watch \
+    procps-ng \
     curl \
     wget && \
     microdnf clean all

--- a/images/network/debug/Dockerfile
+++ b/images/network/debug/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
-    watch \
+    procps \
     curl \
     wget \
     dnsutils \

--- a/images/postgresql/13/Dockerfile
+++ b/images/postgresql/13/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
-    watch \
+    procps \
     curl \
     wget \
     gnupg \

--- a/images/postgresql/14/Dockerfile
+++ b/images/postgresql/14/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
-    watch \
+    procps \
     curl \
     wget \
     gnupg \

--- a/images/postgresql/15/Dockerfile
+++ b/images/postgresql/15/Dockerfile
@@ -3,7 +3,7 @@ FROM debian:bookworm-slim@sha256:60eac759739651111db372c07be67863818726f754804b8
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
-    watch \
+    procps \
     curl \
     wget \
     gnupg \

--- a/images/ruby/3.3/Dockerfile
+++ b/images/ruby/3.3/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.3-slim@sha256:5340ab7cd6317c45a0a7e2818857b930ff61ee92ffd661dec72738
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
-    watch \
+    procps \
     curl \
     wget \
     git \

--- a/images/ruby/3.4/Dockerfile
+++ b/images/ruby/3.4/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:3.4-slim@sha256:634fb60b00d033da01c2062f2f067cd29f4d16a26ed0c0aa37e4e2
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
-    watch \
+    procps \
     curl \
     wget \
     git \

--- a/images/ruby/4.0/Dockerfile
+++ b/images/ruby/4.0/Dockerfile
@@ -3,7 +3,7 @@ FROM ruby:4.0-slim@sha256:3d2d07ec3c267107a2a253327c108c1e5b74ea84cfa5ab125f127b
 RUN apt-get update && \
     apt-get install -y --no-install-recommends \
     ca-certificates \
-    watch \
+    procps \
     curl \
     wget \
     git \


### PR DESCRIPTION
This pull request updates the system utilities installed in several Dockerfiles, replacing the `watch` utility with the more comprehensive `procps` (or `procps-ng` on some distributions), which includes tools like `ps`, `top`, and `watch`. The documentation is also updated to reflect this change and clarify the tools included. These changes help standardize the set of process monitoring tools available in the images.

**Dockerfile updates:**

* Replaced the installation of the `watch` utility with `procps` in all Debian-based Dockerfiles, ensuring that `ps`, `top`, and `watch` are all available. This change affects the following images: `mysql/8.0`, `network/debug`, `postgresql/13`, `postgresql/14`, `postgresql/15`, `ruby/3.3`, `ruby/3.4`, and `ruby/4.0` [[1]](diffhunk://#diff-2c83e1555103616adc5c3c87f9bcbc57076fc4b9706ef6864d30aa7108178c1dL7-R7) [[2]](diffhunk://#diff-1a3c2c5a47e1783c31cb4aae570110a67fa5399c5f447c81e5d26fab9781e3d4L6-R6) [[3]](diffhunk://#diff-d955ece736ab33e89933e1f7000da048f73892eb2501befadf1642f5690879cbL6-R6) [[4]](diffhunk://#diff-920ae5c71f03ecee89c2c48b9e41b5fae7e49e099153b10ca5ee0b8f8d192a1fL6-R6) [[5]](diffhunk://#diff-8b172c11bcb66f74cac46e026b62bd1c48e50ef70ed3d5758c4a66c02b4d8850L6-R6) [[6]](diffhunk://#diff-b825972b8376f859d6a1668d11904aa2a1183f8b6304e28bc0dec1375a64883cL6-R6) [[7]](diffhunk://#diff-9d9258ce335e19cee2a7a4c25010fbe61ba40567c03f070687dd83c8d3ce52d0L6-R6) [[8]](diffhunk://#diff-95de15479d76e5ecfebac89337292aaad04146e303e74bdb2166f3038e39a5b2L6-R6).
* Updated Red Hat-based Dockerfiles (`mysql/8.4` and `mysql/9.5.0`) to install `procps-ng` instead of `watch` for consistency with the Debian-based images [[1]](diffhunk://#diff-e5161466333201418e441c53a2b52177115c6f5b0f0afd9168b390e426a4b1d8L4-R4) [[2]](diffhunk://#diff-113661619227561e1746908c4888f4a7a0a4f8b6200ba109141d8ba5603f3432L4-R4).

**Documentation updates:**

* Updated `.github/copilot-instructions.md` to clarify that `procps` provides `ps`, `top`, and `watch`, reflecting the change in the Dockerfiles.
* Minor formatting cleanup in the documentation for improved clarity.